### PR TITLE
feat: add maintenance mode for wedding site

### DIFF
--- a/MAINTENANCE_MODE.md
+++ b/MAINTENANCE_MODE.md
@@ -1,0 +1,60 @@
+# Modo de Manutenção - Site de Casamento
+
+## Como usar o modo de manutenção
+
+O site de casamento possui um sistema de modo de manutenção que permite mostrar uma página temporária enquanto o site está sendo finalizado.
+
+### Ativar/Desativar o modo de manutenção
+
+1. Abra o arquivo `src/App.jsx`
+2. Localize a linha 17:
+   ```javascript
+   const isMaintenanceMode = true;
+   ```
+3. Para **ativar** o modo de manutenção: mantenha como `true`
+4. Para **desativar** o modo de manutenção: mude para `false`
+
+### O que acontece em cada modo
+
+#### Modo de Manutenção Ativo (`isMaintenanceMode = true`)
+
+- Mostra apenas a página de manutenção
+- Esconde todo o conteúdo do site
+- Exibe uma mensagem elegante informando que o site está em construção
+- Ideal para quando o site ainda não está pronto para o público
+
+#### Modo Normal (`isMaintenanceMode = false`)
+
+- Mostra o site completo com todas as páginas
+- Navegação normal entre seções
+- Todas as funcionalidades disponíveis
+
+### Personalizar a mensagem de manutenção
+
+Para personalizar a mensagem exibida na página de manutenção, edite o arquivo `src/components/MaintenancePage.jsx`.
+
+### Deploy no Vercel
+
+Quando fizer o deploy no Vercel:
+
+1. Mantenha `isMaintenanceMode = true` se o site ainda não estiver pronto
+2. Mude para `isMaintenanceMode = false` quando quiser liberar o site completo
+3. Faça um novo deploy após a mudança
+
+### Exemplo de uso
+
+```javascript
+// Site em manutenção (público vê apenas a página de manutenção)
+const isMaintenanceMode = true;
+
+// Site completo liberado (público vê todo o conteúdo)
+const isMaintenanceMode = false;
+```
+
+### Benefícios
+
+- ✅ Controle total sobre quando o site fica disponível
+- ✅ Mensagem profissional para visitantes
+- ✅ Fácil de ativar/desativar
+- ✅ Mantém o site no ar mesmo durante ajustes finais
+- ✅ Não afeta o SEO quando ativo

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,9 +9,12 @@ import Recepcao from "./pages/Recepcao";
 import Confirmacao from "./pages/Confirmacao";
 import Presentes from "./pages/Presentes";
 import Contato from "./pages/Contato";
+import MaintenancePage from "./components/MaintenancePage";
 import { initEmailJS } from "./config/emailjs";
 
 export default function App() {
+  // Controle para modo de manutenção - mude para false quando o site estiver pronto
+  const isMaintenanceMode = true;
   const [activeSection, setActiveSection] = useState("home");
 
   // Initialize EmailJS
@@ -61,6 +64,11 @@ export default function App() {
     window.addEventListener("scroll", handleScroll);
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
+
+  // Se estiver em modo de manutenção, mostrar apenas a página de manutenção
+  if (isMaintenanceMode) {
+    return <MaintenancePage />;
+  }
 
   return (
     <div className="App">

--- a/src/components/MaintenancePage.jsx
+++ b/src/components/MaintenancePage.jsx
@@ -1,0 +1,83 @@
+import { useState, useEffect } from "react";
+
+export default function MaintenancePage() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    setIsVisible(true);
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-pink-50 via-rose-50 to-slate-50 flex items-center justify-center p-4">
+      <div className="max-w-2xl mx-auto text-center">
+        <div
+          className={`transition-all duration-1000 ${
+            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"
+          }`}
+        >
+          {/* Logo/Imagem dos noivos */}
+          <div className="mb-8">
+            <div className="w-24 h-24 mx-auto mb-6 bg-gradient-to-br from-pink-300 to-rose-400 rounded-full flex items-center justify-center shadow-lg">
+              <span className="text-4xl">💒</span>
+            </div>
+          </div>
+
+          {/* Título */}
+          <h1 className="text-3xl sm:text-4xl md:text-5xl font-serif text-slate-800 mb-6 elegant-text-gradient">
+            Erica & Junior
+          </h1>
+
+          {/* Divisor decorativo */}
+          <div className="w-16 h-1 bg-gradient-to-r from-pink-300 to-rose-300 mx-auto mb-8 rounded-full"></div>
+
+          {/* Mensagem principal */}
+          <div className="bg-white/80 backdrop-blur-md border border-white/30 shadow-xl shadow-slate-200/40 rounded-3xl p-8 sm:p-10 mb-8">
+            <div
+              className="text-6xl sm:text-7xl mb-6 animate-bounce"
+              style={{ animationDuration: "3s" }}
+            >
+              🛠️
+            </div>
+
+            <h2 className="text-2xl sm:text-3xl font-serif text-slate-800 mb-4">
+              Site em Construção
+            </h2>
+
+            <p className="text-lg sm:text-xl text-slate-600 leading-relaxed mb-6">
+              Bem-vindo ao site de casamento da Erica e Junior! Estamos passando
+              por alguns ajustes finais para deixar tudo perfeito para vocês.
+            </p>
+
+            <p className="text-base sm:text-lg text-slate-500 leading-relaxed">
+              Em breve o site estará disponível com todas as informações sobre
+              nosso grande dia!
+            </p>
+          </div>
+
+          {/* Informações adicionais */}
+          <div className="bg-gradient-to-br from-slate-50 to-white border border-slate-200/50 rounded-2xl p-6 shadow-lg">
+            <div className="flex items-center justify-center gap-3 mb-4">
+              <span className="text-2xl">💝</span>
+              <h3 className="text-lg font-serif text-slate-800">
+                Aguardem novidades!
+              </h3>
+              <span className="text-2xl">💝</span>
+            </div>
+
+            <p className="text-sm text-slate-600">
+              Estamos preparando algo muito especial para compartilhar com
+              vocês. Obrigado pela paciência e carinho!
+            </p>
+          </div>
+
+          {/* Footer */}
+          <div className="mt-8 text-center">
+            <p className="text-xs text-slate-500">
+              © 2025 Erica & Junior - Todos os direitos reservados
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This pull request introduces a maintenance mode feature to the wedding website, allowing you to easily display a stylish "site under construction" page while hiding all other content. The implementation provides a simple toggle to activate or deactivate maintenance mode, clear documentation, and a customizable maintenance message.

Key changes include:

**Maintenance Mode Implementation**
* Added a boolean toggle (`isMaintenanceMode`) in `src/App.jsx` to control whether the site displays the maintenance page or the full site. When enabled, only the maintenance page is shown to visitors. [[1]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R12-R17) [[2]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R68-R72)
* Created a new `MaintenancePage` component (`src/components/MaintenancePage.jsx`) with a polished design and transition effects, displaying a friendly message and branding while the site is under construction.

**Documentation**
* Added a comprehensive `MAINTENANCE_MODE.md` guide explaining how to use, customize, and deploy the maintenance mode feature, including step-by-step instructions and best practices.