### PR TITLE
feat: add mobile dev mode and clean maintenance page

### DIFF
--- a/MAINTENANCE_MODE.md
+++ b/MAINTENANCE_MODE.md
@@ -51,6 +51,33 @@ const isMaintenanceMode = true;
 const isMaintenanceMode = false;
 ```
 
+### Modo Desenvolvedor
+
+O site possui um modo desenvolvedor que permite acessar o conteúdo completo mesmo com o modo de manutenção ativo:
+
+#### Como ativar o modo desenvolvedor:
+
+**Desktop:**
+
+1. **Combinação de teclas**: Pressione `Ctrl + Shift + D`
+2. **Para desativar**: Pressione `Ctrl + Shift + D` novamente
+
+**Mobile:**
+
+1. **Toques secretos**: Toque 5 vezes no canto superior esquerdo da tela
+2. **Botão aparecerá**: Um botão azul "🛠️ Ativar Dev Mode" aparecerá no canto superior esquerdo
+3. **Clique no botão**: Para ativar/desativar o modo desenvolvedor
+4. **Auto-hide**: O botão desaparece automaticamente após 3 segundos
+
+**Indicador visual**: Quando ativo, aparece um badge "🛠️ DEV MODE" no canto superior direito
+
+#### Benefícios do modo desenvolvedor:
+
+- ✅ Permite testar o site completo durante o desenvolvimento
+- ✅ Não afeta o modo de manutenção para visitantes normais
+- ✅ Fácil de ativar/desativar
+- ✅ Indicador visual claro quando ativo
+
 ### Benefícios
 
 - ✅ Controle total sobre quando o site fica disponível
@@ -58,3 +85,4 @@ const isMaintenanceMode = false;
 - ✅ Fácil de ativar/desativar
 - ✅ Mantém o site no ar mesmo durante ajustes finais
 - ✅ Não afeta o SEO quando ativo
+- ✅ Modo desenvolvedor para testes

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,45 @@ export default function App() {
   // Controle para modo de manutenção - mude para false quando o site estiver pronto
   const isMaintenanceMode = true;
   const [activeSection, setActiveSection] = useState("home");
+  const [devMode, setDevMode] = useState(false);
+  const [showDevButton, setShowDevButton] = useState(false);
+
+  // Sistema de modo desenvolvedor - ativar com Ctrl+Shift+D (desktop) ou toques (mobile)
+  useEffect(() => {
+    const handleKeyPress = (e) => {
+      if (e.ctrlKey && e.shiftKey && e.key === "D") {
+        e.preventDefault();
+        setDevMode((prev) => !prev);
+        console.log("Modo desenvolvedor:", !devMode ? "ativado" : "desativado");
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyPress);
+    return () => window.removeEventListener("keydown", handleKeyPress);
+  }, [devMode]);
+
+  // Sistema de toques para mobile - 5 toques no canto superior esquerdo
+  useEffect(() => {
+    let tapCount = 0;
+
+    const handleTap = (e) => {
+      const x = e.clientX;
+      const y = e.clientY;
+
+      // Verifica se o toque foi no canto superior esquerdo (área de 50x50px)
+      if (x <= 50 && y <= 50) {
+        tapCount += 1;
+        if (tapCount >= 5) {
+          setShowDevButton(true);
+          setTimeout(() => setShowDevButton(false), 3000); // Esconde após 3 segundos
+          tapCount = 0;
+        }
+      }
+    };
+
+    document.addEventListener("click", handleTap);
+    return () => document.removeEventListener("click", handleTap);
+  }, []);
 
   // Initialize EmailJS
   useEffect(() => {
@@ -66,12 +105,34 @@ export default function App() {
   }, []);
 
   // Se estiver em modo de manutenção, mostrar apenas a página de manutenção
-  if (isMaintenanceMode) {
+  if (isMaintenanceMode && !devMode) {
     return <MaintenancePage />;
   }
 
   return (
     <div className="App">
+      {/* Indicador de modo desenvolvedor */}
+      {devMode && (
+        <div className="fixed top-4 right-4 z-50 bg-yellow-500 text-black px-3 py-1 rounded-full text-xs font-bold shadow-lg">
+          🛠️ DEV MODE
+        </div>
+      )}
+
+      {/* Botão de modo desenvolvedor para mobile */}
+      {showDevButton && (
+        <div className="fixed top-4 left-4 z-50 bg-blue-500 text-white px-4 py-2 rounded-lg text-sm font-bold shadow-lg">
+          <button
+            onClick={() => {
+              setDevMode((prev) => !prev);
+              setShowDevButton(false);
+            }}
+            className="flex items-center gap-2"
+          >
+            🛠️ {devMode ? "Desativar" : "Ativar"} Dev Mode
+          </button>
+        </div>
+      )}
+
       <Toaster
         position="top-right"
         toastOptions={{


### PR DESCRIPTION
This pull request introduces a developer mode ("modo desenvolvedor") that allows bypassing the maintenance screen for testing and development purposes. The developer mode can be activated via a keyboard shortcut on desktop or a hidden tap gesture on mobile, and provides a clear visual indicator when active. These changes enhance the development workflow without impacting the maintenance experience for regular visitors.

**Developer mode functionality:**

* Added state management and logic in `App.jsx` to support toggling developer mode via `Ctrl+Shift+D` on desktop and five taps in the upper-left corner on mobile, including auto-hiding a special activation button for mobile users.
* Updated the maintenance mode logic so that when developer mode is active, the full site is accessible even if maintenance mode is enabled.
* Added a visual "🛠️ DEV MODE" badge in the top-right corner when developer mode is active, and a temporary blue button for toggling developer mode on mobile.

**Documentation:**

* Updated `MAINTENANCE_MODE.md` to document the new developer mode, including activation instructions for both desktop and mobile, its benefits, and its visual indicators.