### PR TITLE
feat: reorganize contact page layout and add Google Maps links

### DIFF
--- a/src/pages/Contato.jsx
+++ b/src/pages/Contato.jsx
@@ -132,26 +132,6 @@ export default function Contato() {
               <div className="space-y-4 sm:space-y-6">
                 <div className="bg-white/80 backdrop-blur-sm border border-white/20 p-4 sm:p-6 md:p-8 rounded-xl sm:rounded-2xl hover:shadow-lg transition-all duration-300">
                   <div className="flex items-start gap-4 sm:gap-6">
-                    <div className="w-12 h-12 sm:w-16 sm:h-16 bg-gradient-to-br from-pink-400 to-rose-500 rounded-full flex items-center justify-center text-white text-lg sm:text-2xl shadow-lg">
-                      🎉
-                    </div>
-                    <div>
-                      <h3 className="text-lg sm:text-xl font-serif text-slate-800 mb-2 sm:mb-3 elegant-text-gradient">
-                        Local da Festa
-                      </h3>
-                      <p className="text-sm sm:text-base text-slate-600 mb-1 sm:mb-2">
-                        Mansão Jaraguá
-                      </p>
-                      <p className="text-xs sm:text-sm text-slate-500">
-                        Rua Comendador J. de Matos, 429 – Vila Clarice, São
-                        Paulo – SP, 05177-100
-                      </p>
-                    </div>
-                  </div>
-                </div>
-
-                <div className="bg-white/80 backdrop-blur-sm border border-white/20 p-4 sm:p-6 md:p-8 rounded-xl sm:rounded-2xl hover:shadow-lg transition-all duration-300">
-                  <div className="flex items-start gap-4 sm:gap-6">
                     <div className="w-12 h-12 sm:w-16 sm:h-16 bg-gradient-to-br from-green-400 to-emerald-500 rounded-full flex items-center justify-center text-white text-lg sm:text-2xl shadow-lg">
                       💬
                     </div>
@@ -195,15 +175,49 @@ export default function Contato() {
                     </div>
                     <div>
                       <h3 className="text-lg sm:text-xl font-serif text-slate-800 mb-2 sm:mb-3 elegant-text-gradient">
-                        Endereço
+                        Local da Cerimônia
                       </h3>
-                      <p className="text-sm sm:text-base text-slate-600 mb-1 sm:mb-2">
-                        Igreja Nossa Senhora da Conceição
-                      </p>
-                      <p className="text-xs sm:text-sm text-slate-500">
-                        Rua Nossa Sra. da Conceição, 117 – Jaraguá, São Paulo –
-                        SP, 05181-280
-                      </p>
+                      <a 
+                        href="https://www.google.com/maps/search/?api=1&query=Rua+Nossa+Sra.+da+Conceição,+117+–+Jaraguá,+São+Paulo+–+SP,+05181-280"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="block hover:text-pink-600 transition-colors duration-300"
+                      >
+                        <p className="text-sm sm:text-base text-slate-600 mb-1 sm:mb-2 hover:underline">
+                          Igreja Nossa Senhora da Conceição
+                        </p>
+                        <p className="text-xs sm:text-sm text-slate-500">
+                          Rua Nossa Sra. da Conceição, 117 – Jaraguá, São Paulo –
+                          SP, 05181-280
+                        </p>
+                      </a>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="bg-white/80 backdrop-blur-sm border border-white/20 p-4 sm:p-6 md:p-8 rounded-xl sm:rounded-2xl hover:shadow-lg transition-all duration-300">
+                  <div className="flex items-start gap-4 sm:gap-6">
+                    <div className="w-12 h-12 sm:w-16 sm:h-16 bg-gradient-to-br from-pink-400 to-rose-500 rounded-full flex items-center justify-center text-white text-lg sm:text-2xl shadow-lg">
+                      🎉
+                    </div>
+                    <div>
+                      <h3 className="text-lg sm:text-xl font-serif text-slate-800 mb-2 sm:mb-3 elegant-text-gradient">
+                        Local da Recepção
+                      </h3>
+                      <a 
+                        href="https://www.google.com/maps/search/?api=1&query=Rua+Comendador+J.+de+Matos,+429+-+Vila+Clarice,+São+Paulo+-+SP,+05177-100"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="block hover:text-pink-600 transition-colors duration-300"
+                      >
+                        <p className="text-sm sm:text-base text-slate-600 mb-1 sm:mb-2 hover:underline">
+                          Mansão Jaraguá
+                        </p>
+                        <p className="text-xs sm:text-sm text-slate-500">
+                          Rua Comendador J. de Matos, 429 – Vila Clarice, São
+                          Paulo – SP, 05177-100
+                        </p>
+                      </a>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
- Reorder contact information cards for better flow:
  1. WhatsApp (most direct contact)
  2. Email (formal contact)
  3. Local da Cerimônia (with Google Maps link)
  4. Local da Recepção (with Google Maps link)
- Add clickable Google Maps links to both wedding locations
- Improve titles: 'Local da Cerimônia' and 'Local da Recepção'
- Add hover effects with pink color and underline transitions
- Maintain consistent styling and responsive design