### PR TITLE
feat: implementar roteamento baseado em hash para links diretos

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -54,6 +54,42 @@ export default function App() {
     initEmailJS();
   }, []);
 
+  // Hash routing - navigate to section based on URL hash
+  useEffect(() => {
+    const handleHashChange = () => {
+      const hash = window.location.hash.slice(1); // Remove the # symbol
+      if (hash && hash !== activeSection) {
+        // Valid sections
+        const validSections = [
+          "home",
+          "historia",
+          "cerimonia",
+          "recepcao",
+          "presentes",
+          "confirmacao",
+          "contato",
+        ];
+        if (validSections.includes(hash)) {
+          setActiveSection(hash);
+          // Scroll to section after a short delay to ensure DOM is ready
+          setTimeout(() => {
+            scrollToSection(hash);
+          }, 100);
+        }
+      }
+    };
+
+    // Check initial hash on page load
+    handleHashChange();
+
+    // Listen for hash changes
+    window.addEventListener("hashchange", handleHashChange);
+
+    return () => {
+      window.removeEventListener("hashchange", handleHashChange);
+    };
+  }, [activeSection]);
+
   // Smooth scroll to section
   const scrollToSection = (sectionId) => {
     const element = document.getElementById(sectionId);


### PR DESCRIPTION
- Adicionar listener para mudanças na URL hash
- Verificar hash inicial ao carregar a página
- Navegar automaticamente para seção correta baseada no hash
- Suportar links diretos como #presentes, #historia, etc.
- Manter funcionalidade de scroll suave para seções